### PR TITLE
Clean install directory before installing

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -113,8 +113,13 @@ jobs:
       #    nmake test
       - name: "Install OpenSSL (64-bit)"
         shell: cmd
+        # NOTE: the GitHub action runners' Windows VM seems to include
+        #  OpenSSL 1.1.x at the same path where we install OpenSSL, so
+        #  let's delete that first.  Don't do this on your own machine!
         run: |
           call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+          rmdir /q /s "%ProgramW6432%\OpenSSL"
+          rmdir /q /s "%CommonProgramW6432%\SSL"
           cd src
           nmake install
       - name: "Bundle OpenSSL (64-bit)"
@@ -210,9 +215,14 @@ jobs:
       #    nmake test
       - name: "Install OpenSSL (32-bit)"
         shell: cmd
+        # NOTE: the GitHub action runners' Windows VM seems to include
+        #  OpenSSL 1.1.x at the same path where we install OpenSSL, so
+        #  let's delete that first.  Don't do this on your own machine!
         run: |
           call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars32.bat"
           cd src
+          rmdir /q /s "%ProgramFiles(x86)%\OpenSSL"
+          rmdir /q /s "%CommonProgramFiles(x86)%\SSL"
           nmake install
       - name: "Bundle OpenSSL (32-bit)"
         shell: cmd


### PR DESCRIPTION
OpenSSL 1.1.x is already installed on the GitHub actions Windows VMs. When running `nmake install`, our files get merged into the same directory.  This causes the `7z a -tzip` command to pick up both the files we installed and whatever was already there.  Let's ensure we get a clear archive!