### PR TITLE
Clean install directory before installing

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -149,6 +149,8 @@ jobs:
       - name: "Extract and install OpenSSL binaries (64-bit)"
         shell: cmd
         run: |
+          rmdir /q /s "%ProgramW6432%\OpenSSL"
+          rmdir /q /s "%CommonProgramW6432%\SSL"
           7z x openssl-binaries-x64.zip -o"%ProgramW6432%\" OpenSSL\ -y
           7z x openssl-binaries-x64.zip -o"%CommonProgramW6432%\" SSL\ -y
       - name: "Generate Visual Studio 2019 Solution (64-bit)"
@@ -251,6 +253,8 @@ jobs:
       - name: "Extract and install OpenSSL binaries (32-bit)"
         shell: cmd
         run: |
+          rmdir /q /s "%ProgramFiles(x86)%\OpenSSL"
+          rmdir /q /s "%CommonProgramFiles(x86)%\SSL"
           7z x openssl-binaries-x86.zip -o"%ProgramFiles(x86)%\" OpenSSL\ -y
           7z x openssl-binaries-x86.zip -o"%CommonProgramFiles(x86)%\" SSL\ -y
       - name: "Generate Visual Studio 2019 Solution (32-bit)"


### PR DESCRIPTION
Part 2.  We already do this before `nmake install`, after building. However, we also need to do it before installing the binaries we generated (the same problem arises there).