### PR TITLE
Fix CMake test on 64-bit machines

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -166,9 +166,21 @@ jobs:
           cmake --build . --target ALL_BUILD --config Release
       - name: "Execute simple integration test (64-bit)"
         shell: cmd
+        # NOTE: the OpenSSL DLL must be in PATH (or copied into the
+        #   same folder as our test executable).  Normally, we'd
+        #   append the path to the OpenSSL binaries to PATH, but if
+        #   anything else in PATH has a DLL with the same name, the
+        #   other one will be found first and we might not get the
+        #   version we just built when running our tests.
+        #
+        #   To work around this issue, insert the binaries at the
+        #   front of PATH when running these tests.  This is safe in a
+        #   throwaway VM (or in a script that temporarily edits PATH
+        #   in a dedicated terminal), but don't do this on anybody's
+        #   machine.
         run: |
           cd build\
-          set PATH=%PATH%;%ProgramW6432%\OpenSSL\bin
+          set PATH=%ProgramW6432%\OpenSSL\bin;%PATH%
           ctest --build-config Release --output-on-failure
 
   build-windows-2019-vs-2019-x86:
@@ -270,9 +282,21 @@ jobs:
           cmake --build . --target ALL_BUILD --config Release
       - name: "Execute simple integration test (32-bit)"
         shell: cmd
+        # NOTE: the OpenSSL DLL must be in PATH (or copied into the
+        #   same folder as our test executable).  Normally, we'd
+        #   append the path to the OpenSSL binaries to PATH, but if
+        #   anything else in PATH has a DLL with the same name, the
+        #   other one will be found first and we might not get the
+        #   version we just built when running our tests.
+        #
+        #   To work around this issue, insert the binaries at the
+        #   front of PATH when running these tests.  This is safe in a
+        #   throwaway VM (or in a script that temporarily edits PATH
+        #   in a dedicated terminal), but don't do this on anybody's
+        #   machine.
         run: |
           cd build\
-          set PATH=%PATH%;%ProgramFiles(x86)%\OpenSSL\bin
+          set PATH=%ProgramFiles(x86)%\OpenSSL\bin;%PATH%
           ctest --build-config Release --output-on-failure
 
   release:


### PR DESCRIPTION
On 64-bit machines, our `ctest` run would fail for OpenSSL 1.1.1s because something else in PATH provided `libssl-1_1-x64.dll` as well. It's not clear what was conflicting on the GitHub runner VMs, but I reproduced this on my machine with Git for Windows.

We didn't encounter this for OpenSSL 3.x, nor for OpenSSL 1.1.1s 32-bit binaries, but technically it could happen for any other OpenSSL version and/or architecture depending on what software is installed on the machine.

Work around the issue by forcing the path to our binaries at the front of `PATH` while running tests.

Note that this wouldn't be an acceptable solution when installing the binaries for a real program.  If you were to prepare a real application and install it, you should probably copy the DLLs and install them in the same folder as your executable.