### PR TITLE
Copy OpenSSL dynamic-link libraries to the output folder

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -180,7 +180,6 @@ jobs:
         #   machine.
         run: |
           cd build\
-          set PATH=%ProgramW6432%\OpenSSL\bin;%PATH%
           ctest --build-config Release --output-on-failure
 
   build-windows-2019-vs-2019-x86:
@@ -296,7 +295,6 @@ jobs:
         #   machine.
         run: |
           cd build\
-          set PATH=%ProgramFiles(x86)%\OpenSSL\bin;%PATH%
           ctest --build-config Release --output-on-failure
 
   release:

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -20,6 +20,39 @@ message("OpenSSL include directory: ${OPENSSL_INCLUDE_DIR}")
 message("OpenSSL libraries: ${OPENSSL_LIBRARIES}")
 include_directories(${OPENSSL_INCLUDE_DIR})
 
+# Dynamic libraries on Windows need to be copied to the output folder.
+# This is required on all platforms and becomes most obvious when
+# building OpenSSL 1.1.x 64-bit on GitHub Windows runners, which have
+# `libssl-1_1-x64.dll` in `C:\Windows\system32`, preventing us from
+# installing our binaries anywhere but in the same directory as our
+# executable (see Dynamic-Link Library Search Order in Windows
+# documentation).
+if (WIN32)
+
+  # We'll need the path to the directory containing the OpenSSL DLLs.
+  #
+
+  # Compute the path relative to any of the OpenSSL `.lib` files with
+  # the assumption that the `lib/` and `bin/ folders are side-by-side,
+  # which is what OpenSSL's `nmake install` command does for us.
+  #
+  # Note that it's tempting to use `OPENSSL_INCLUDE_DIR` here, but
+  # that is unreliable because it usually finds
+  # `C:/Strawberry/c/include` before the "official" location.
+  cmake_path(GET OPENSSL_SSL_LIBRARY PARENT_PATH OPENSSL_BINARY_DIR)
+  cmake_path(GET OPENSSL_BINARY_DIR PARENT_PATH OPENSSL_BINARY_DIR)
+  set(OPENSSL_BINARY_DIR "${OPENSSL_BINARY_DIR}/bin")
+  message("OPENSSL_BINARY_DIR: ${OPENSSL_BINARY_DIR}")
+
+  # Search for all DLL files in the OpenSSL binaries.  Normally, this
+  # list will contain two files: `libcrypto*.dll` and `libssl*.dll`.
+  # Note that the naming conventions change from OpenSSL 1.1.x to 3.x
+  # and OpenSSL is free to change how many DLLs they publish, so we're
+  # better off globbing for these files.
+  file(GLOB OPENSSL_DYNAMIC_LIBRARIES "${OPENSSL_BINARY_DIR}/*.dll")
+  message("OPENSSL_DYNAMIC_LIBRARIES: ${OPENSSL_DYNAMIC_LIBRARIES}")
+endif()
+
 # Create the C++ executable that will embed Python.
 add_executable(TestOpenSSL main.cpp)
 
@@ -28,6 +61,15 @@ target_link_libraries(
   TestOpenSSL
   ${OPENSSL_LIBRARIES}
 )
+if (WIN32)
+  add_custom_command(
+    TARGET TestOpenSSL POST_BUILD
+    COMMAND
+      ${CMAKE_COMMAND} -E copy_if_different
+      ${OPENSSL_DYNAMIC_LIBRARIES}
+      "$<TARGET_FILE_DIR:TestOpenSSL>"
+  )
+endif()
 
 # Add simple test to confirm that the program works.
 enable_testing()


### PR DESCRIPTION
I finally tracked down the issue for OpenSSL 1.1.x on GitHub Windows runners.  The root cause is that the runners have `libssl-1_1-x64.dll` in `C:\Windows\system32`.  Given the documented Dynamic-link library search order (see Windows documetnation), this file is found before `PATH` is searched.  The ONLY path that is searched before `C:\Windows\system32` is the directory containing the application executable.  This means the ONLY way to resolve our OpenSSL binaries on this machine is to copy them in the same folder as the executable and we can never correctly resolve with PATH, no matter the order in which we add our OpenSSL binary directory in there.

This is rather unfortunate because CMake's FindOpenSSL module doesn't expose any helpers to achieve this and we have to compute the path to the DLLs relative to `${OPENSSL_CRYPTO_LIBRARY}` or `${OPENSSL_SSL_LIBRARY}`.