### PR TITLE
Remove duplicate checkout in release job

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -522,7 +522,6 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: openssl-binary-distribution-x64-dll
-      - uses: actions/checkout@v3
       - name: "Retrieve binaries (64-bit LIB)"
         uses: actions/download-artifact@v3
         with:


### PR DESCRIPTION
The duplicate checkout was causing `openssl-binaries-x64-dll.zip` to be deleted, which would eventually lead to an error because this file is required.