### PR TITLE
Fix another syntax error in release job

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -542,7 +542,7 @@ jobs:
           mv openssl-binaries-x64-static.zip openssl-${{ github.ref_name }}-binaries-x64-static.zip
           mv openssl-binaries-x86-dll.zip openssl-${{ github.ref_name }}-binaries-x86-dll.zip
           mv openssl-binaries-x86-static.zip openssl-${{ github.ref_name }}-binaries-x86-static.zip
-          gh release create --verify-tag ${{ github.ref_name }} \ \
+          gh release create --verify-tag ${{ github.ref_name }} \
             openssl-${{ github.ref_name }}-binaries-x64-dll.zip \
             openssl-${{ github.ref_name }}-binaries-x64-static.zip \
             openssl-${{ github.ref_name }}-binaries-x86-dll.zip \


### PR DESCRIPTION
Unclear error `stat : no such file or directory` from GitHub action logs.  Looks like we have a duplicate escape character...